### PR TITLE
Add optional parameter to skip last commit messages

### DIFF
--- a/src/CakeExt.Git/GitAlias.cs
+++ b/src/CakeExt.Git/GitAlias.cs
@@ -37,8 +37,9 @@ public static class GitAlias
     /// Gets the last commit message
     /// </summary>
     [CakeMethodAlias]
-    public static string GitGetLastCommitMessage(this ICakeContext context) =>
-        context.Git("log -1 --pretty=format:'%s'").FirstOrDefault() ?? "";
+    public static string GitGetLastCommitMessage(this ICakeContext context, int skip = 0) =>
+        context.Git($"log -{1+skip} --pretty=format:'%s'")
+            .FirstOrDefault() ?? "";
 
     /// <summary>
     /// Gets the current branch name


### PR DESCRIPTION
When using GetLastCommitMessage in PR Builds, we get an automatically created Merge from DevOps. But we want out own last commit message. So we will be able to optionally skip n-Commit messages.